### PR TITLE
Update votes-collector.fc

### DIFF
--- a/src/func/jetton-bridge/votes-collector.fc
+++ b/src/func/jetton-bridge/votes-collector.fc
@@ -65,14 +65,19 @@ cell load_data() inline_ref {
         if (external_ids.slice_data_empty?()) {
             external_ids = external_ids.preload_ref().begin_parse();
         }
+		
+        if (external_ids.slice_size() >= 256 / 8) {
         int voting_id = external_ids~load_uint(256);
         (cell external_votings', slice voting, int voting_found?) = external_votings.udict_delete_get?(256, voting_id);
         if (voting_found?) {
-            int last_update = voting~load_uint(32);
-            if (bound > last_update) {
-                ;; remove only old votings
-                external_votings = external_votings';
-            }
+        int last_update = voting~load_uint(32);
+        if (bound > last_update) {
+        ;; remove only old votings
+         external_votings = external_votings';
+                                  }
+                            }
+        } else {
+        throw_unless(333, false);
         }
     }
 

--- a/src/func/jetton-bridge/votes-collector.fc
+++ b/src/func/jetton-bridge/votes-collector.fc
@@ -37,9 +37,14 @@ cell load_data() inline_ref {
             signatures = new_dict();
         }
     }
+
+	if (signature.slice_size() == 520 / 8) {
     int secp_key = key~load_uint(256);
     int success? = signatures~udict_add?(256, secp_key, signature);
     throw_unless(324, success?);
+    } else {
+    throw_unless(326, false);
+    }
     builder new_voting_data = begin_cell()
             .store_uint(now(), 32)
             .store_uint(oracles_address, 256)


### PR DESCRIPTION
issue:The vote_on_external_chain function does not check the length of the signature slice before attempting to parse it as a 520-bit integer. This could lead to out-of-bounds memory access if the slice is not of the correct length. solution:
add an if statement to check the length of the signature slice before parsing it as a 520-bit integer